### PR TITLE
upstream sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install blocksec2go-ethereum
 
 After creating an instance of `Blocksec2Go` you can use it to generate signatures for transaction dicts. When passed raw tx, `sign_transaction()` will return a hex string of RLP-encoded signed transaction that can be directly consumed by `web3.eth.sendRawTransaction()`.
 
+The replay attack protection introduced with [EIP-155](https://eips.ethereum.org/EIPS/eip-155) is used by default. Set `chain_id=None` to force the legacy behaviour for backward compatibility.
 ### Transfer Ether
 
 Below you will find an example of signing a simple Ether transfer:

--- a/blocksec2go_ethereum/_signer.py
+++ b/blocksec2go_ethereum/_signer.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Tuple
+from typing import Tuple, Optional
 
 import blocksec2go
 from blocksec2go.comm.pyscard import open_pyscard
@@ -18,7 +18,7 @@ Signature = Tuple[int, int, int]
 
 
 class Blocksec2GoSigner:
-    def __init__(self, key_id: int = 1, chain_id: int = 1, connect_retry_count: int = 5):
+    def __init__(self, key_id: int = 1, chain_id: Optional[int] = 1, connect_retry_count: int = 5):
         self._key_id = key_id
         self._chain_id = chain_id
         self._connect_retry_count = connect_retry_count

--- a/blocksec2go_ethereum/_utils.py
+++ b/blocksec2go_ethereum/_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Optional
 
 import ecdsa
 from eth_typing import ChecksumAddress
@@ -34,6 +34,9 @@ def address_from_public_key(public_key: bytes) -> ChecksumAddress:
     return Web3.toChecksumAddress(address)
 
 
-def get_v(sig: UnrecoverableSignature, tx_hash: bytes, pub_key: bytes, chain_id: int) -> int:
+def get_v(sig: UnrecoverableSignature, tx_hash: bytes, pub_key: bytes, chain_id: Optional[int]) -> int:
     recovery_id = find_recovery_id(sig, tx_hash, pub_key)
+
+    if not chain_id:
+        return 27 + recovery_id
     return 35 + recovery_id + (chain_id * 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ blocksec2go==1.2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
-cryptography==3.2
+cryptography==3.3.2
 cytoolz==0.10.1
 distlib==0.3.0
 ecdsa==0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ blocksec2go==1.2
 certifi==2019.11.28
 cffi==1.14.0
 chardet==3.0.4
-cryptography==2.8
+cryptography==3.2
 cytoolz==0.10.1
 distlib==0.3.0
 ecdsa==0.15

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='blocksec2go-ethereum',
-    version='0.1.0',
+    version='0.2.0',
     description='Wrapper for blocksec2go allowing easy hardware-based signing of Ethereum transactions',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,3 +28,9 @@ def test_address_from_public_key():
 def test_get_v():
     returned_v = get_v(test_unrecoverable_signature, test_tx_hash, test_pub_key, test_chain_id)
     assert test_signature[0] == returned_v
+
+
+def test_get_v_legacy():
+    returned_v = get_v(test_unrecoverable_signature, test_tx_hash, test_pub_key, None)
+    legacy_v = test_signature[0] - (2 * test_chain_id) - 35 + 27
+    assert legacy_v == returned_v


### PR DESCRIPTION
setting up vaultBumps [cryptography](https://github.com/pyca/cryptography) from 2.8 to 3.2.
- [Release notes](https://github.com/pyca/cryptography/releases)
- [Changelog](https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/pyca/cryptography/compare/2.8...3.2)

Signed-off-by: dependabot[bot] <support@github.com>